### PR TITLE
deps: bump package dependencies

### DIFF
--- a/src/hypr.csproj
+++ b/src/hypr.csproj
@@ -43,18 +43,18 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.8" />
 
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
     <PackageReference Include="Octokit" Version="13.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
    </ItemGroup>
 
      <ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -25,9 +25,9 @@
 
     <ItemGroup>
         <PackageReference Include="FakeItEasy" Version="8.3.0" />
-        <PackageReference Include="FluentAssertions" Version="8.8.0" />
+        <PackageReference Include="FluentAssertions" Version="8.10.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
-        <PackageReference Include="xunit.v3" Version="3.2.0"/>
+        <PackageReference Include="xunit.v3" Version="3.2.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Updated the safe dependency set in `src/hypr.csproj` and `tests/tests.csproj`
- Bumped `Microsoft.Extensions.*` packages to `10.0.8`
- Upgraded `System.CommandLine` to `2.0.8`, `FluentAssertions` to `8.10.0`, and `xunit.v3` to `3.2.2`
- Deferred higher-risk updates like `LibGit2Sharp`, `Octokit`, `Spectre.Console`, `FakeItEasy`, and `Microsoft.NET.Test.Sdk` for a separate pass

## Testing
- `dotnet restore hypr.slnx`
- `dotnet test hypr.slnx --no-restore`